### PR TITLE
Remove knot interval start search

### DIFF
--- a/lsdo_genie/bsplines/BsplineCurve.py
+++ b/lsdo_genie/bsplines/BsplineCurve.py
@@ -46,8 +46,11 @@ class BsplineCurve:
         row_indices = np.zeros(len(data), np.int32)
         col_indices = np.zeros(len(data), np.int32)
 
+        u_i_starts = np.floor(u_vec*(self.shape_u - self.order_u + 1)).astype(int)
+
         get_basis_curve_matrix(
             self.order_u, self.shape_u, du, u_vec, self.knots_u, 
+            u_i_starts,
             len(u_vec), data, row_indices, col_indices
             )
             

--- a/lsdo_genie/bsplines/BsplineSurface.py
+++ b/lsdo_genie/bsplines/BsplineSurface.py
@@ -57,9 +57,14 @@ class BsplineSurface:
         row_indices = np.zeros(len(data), np.int32)
         col_indices = np.zeros(len(data), np.int32)
 
+        u_i_starts = np.floor(u_vec*(self.shape_u - self.order_u + 1)).astype(int)
+        v_i_starts = np.floor(v_vec*(self.shape_v - self.order_v + 1)).astype(int)
+
         get_basis_surface_matrix(
             self.order_u, self.shape_u, du, u_vec, self.knots_u, 
+            u_i_starts,
             self.order_v, self.shape_v, dv, v_vec, self.knots_v,
+            v_i_starts,
             len(u_vec), data, row_indices, col_indices
             )
 

--- a/lsdo_genie/bsplines/BsplineVolume.py
+++ b/lsdo_genie/bsplines/BsplineVolume.py
@@ -68,10 +68,17 @@ class BsplineVolume:
         row_indices = np.zeros(len(data), np.int32)
         col_indices = np.zeros(len(data), np.int32)
 
+        u_i_starts = np.floor(u_vec*(self.shape_u - self.order_u + 1)).astype(int)
+        v_i_starts = np.floor(v_vec*(self.shape_v - self.order_v + 1)).astype(int)
+        w_i_starts = np.floor(w_vec*(self.shape_w - self.order_w + 1)).astype(int)
+
         get_basis_volume_matrix(
             self.order_u, self.shape_u, du, u_vec, self.knots_u, 
+            u_i_starts,
             self.order_v, self.shape_v, dv, v_vec, self.knots_v,
+            v_i_starts,
             self.order_w, self.shape_w, dw, w_vec, self.knots_w,
+            w_i_starts,
             len(u_vec), data, row_indices, col_indices
             )
             

--- a/lsdo_genie/bsplines/cython/basis0.pxd
+++ b/lsdo_genie/bsplines/cython/basis0.pxd
@@ -1,1 +1,1 @@
-cdef int get_basis0(int order, int num_control_points, double u, double* knot_vector, double* basis)
+cdef int get_basis0(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis)

--- a/lsdo_genie/bsplines/cython/basis0.pyx
+++ b/lsdo_genie/bsplines/cython/basis0.pyx
@@ -1,13 +1,11 @@
-cdef int get_basis0(int order, int num_control_points, double u, double* knot_vector, double* basis0):
+cdef int get_basis0(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis0):
     cdef int i, j1, j2, n
 
-    cdef int i_start = -1
-
     # Find the knot interval
-
-    for i in range(order - 1, num_control_points):
-        if (knot_vector[i] <= u) and (u < knot_vector[i + 1]):
-            i_start = i - order + 1
+    # cdef int i_start = -1
+    # for i in range(order - 1, num_control_points):
+    #     if (knot_vector[i] <= u) and (u < knot_vector[i + 1]):
+    #         i_start = i - order + 1
 
     # Initialize the basis0 to (0., ..., 0., 1.)
     for i in range(order - 1):

--- a/lsdo_genie/bsplines/cython/basis1.pxd
+++ b/lsdo_genie/bsplines/cython/basis1.pxd
@@ -1,4 +1,4 @@
 from libc.stdlib cimport malloc, free
 
 
-cdef int get_basis1(int order, int num_control_points, double u, double* knot_vector, double* basis1)
+cdef int get_basis1(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis1)

--- a/lsdo_genie/bsplines/cython/basis1.pyx
+++ b/lsdo_genie/bsplines/cython/basis1.pyx
@@ -1,18 +1,17 @@
 from libc.stdlib cimport malloc, free
 
-cdef int get_basis1(int order, int num_control_points, double u, double* knot_vector, double* basis1):
+cdef int get_basis1(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis1):
     cdef int i, j1, j2, l, n
     cdef double den, b0_a, b0_b, b1_a, b1_b
 
     cdef double *basis0 = <double *> malloc(order * sizeof(double))
 
-    cdef int i_start = -1
 
     # Find the knot interval
-
-    for i in range(order - 1, num_control_points):
-        if (knot_vector[i] <= u) and (u < knot_vector[i + 1]):
-            i_start = i - order + 1
+    # cdef int i_start = -1
+    # for i in range(order - 1, num_control_points):
+    #     if (knot_vector[i] <= u) and (u < knot_vector[i + 1]):
+    #         i_start = i - order + 1
 
     # Initialize the basis0 to (0., ..., 0., 1.)
     for i in range(order - 1):

--- a/lsdo_genie/bsplines/cython/basis2.pxd
+++ b/lsdo_genie/bsplines/cython/basis2.pxd
@@ -1,3 +1,3 @@
 from libc.stdlib cimport malloc, free
 
-cdef int get_basis2(int order, int num_control_points, double u, double* knot_vector, double* basis2)
+cdef int get_basis2(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis2)

--- a/lsdo_genie/bsplines/cython/basis2.pyx
+++ b/lsdo_genie/bsplines/cython/basis2.pyx
@@ -1,19 +1,17 @@
 from libc.stdlib cimport malloc, free
 
-cdef int get_basis2(int order, int num_control_points, double u, double* knot_vector, double* basis2):
+cdef int get_basis2(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis2):
     cdef int i, j1, j2, l, n
     cdef double den, b0_a, b0_b, b1_a, b1_b, b2_a, b2_b
 
     cdef double *basis0 = <double *> malloc(order * sizeof(double))
     cdef double *basis1 = <double *> malloc(order * sizeof(double))
 
-    cdef int i_start = -1
-
-    # Find the knot interval
-
-    for i in range(order - 1, num_control_points):
-        if (knot_vector[i] <= u) and (u < knot_vector[i + 1]):
-            i_start = i - order + 1
+    # General search for knot interval start is no longer necessary due to standard uniform knot vectors
+    # cdef int i_start = -1
+    # for i in range(order - 1, num_control_points):
+    #     if (knot_vector[i] <= u) and (u < knot_vector[i + 1]):
+    #         i_start = i - order + 1
 
     # Initialize the basis0 to (0., ..., 0., 1.)
     for i in range(order - 1):

--- a/lsdo_genie/bsplines/cython/basis_matrix_curve.pxd
+++ b/lsdo_genie/bsplines/cython/basis_matrix_curve.pxd
@@ -7,5 +7,6 @@ from lsdo_genie.bsplines.cython.basis2 cimport get_basis2
 
 cdef get_basis_curve_matrix(
     int order, int num_control_points, int u_der, double* u_vec, double* knot_vector,
+    int* u_i_starts,
     int num_points, double* data, int* row_indices, int* col_indices,
 )

--- a/lsdo_genie/bsplines/cython/basis_matrix_curve.pyx
+++ b/lsdo_genie/bsplines/cython/basis_matrix_curve.pyx
@@ -4,11 +4,12 @@ from lsdo_genie.bsplines.cython.basis0 cimport get_basis0
 from lsdo_genie.bsplines.cython.basis1 cimport get_basis1
 from lsdo_genie.bsplines.cython.basis2 cimport get_basis2
 
-ctypedef int (*get_basis_func)(int order, int num_control_points, double u, double* knot_vector, double* basis)
+ctypedef int (*get_basis_func)(int order, int num_control_points, double u, int u_i_starts, double* knot_vector, double* basis)
 
 
 cdef get_basis_curve_matrix(
     int order, int num_control_points, int u_der, double* u_vec, double* knot_vector,
+    int* u_i_starts,
     int num_points, double* data, int* row_indices, int* col_indices,
 ):
     cdef int i_pt, i_order, i_start, i_nz
@@ -26,7 +27,7 @@ cdef get_basis_curve_matrix(
 
     i_nz = 0
     for i_pt in range(num_points):
-        i_start = get_basis(order, num_control_points, u_vec[i_pt], knot_vector, basis)
+        i_start = get_basis(order, num_control_points, u_vec[i_pt], u_i_starts[i_pt], knot_vector, basis)
 
         for i_order in range(order):
             data[i_nz] = basis[i_order]

--- a/lsdo_genie/bsplines/cython/basis_matrix_curve_py.pyx
+++ b/lsdo_genie/bsplines/cython/basis_matrix_curve_py.pyx
@@ -6,9 +6,11 @@ from lsdo_genie.bsplines.cython.basis_matrix_curve cimport get_basis_curve_matri
 
 def get_basis_curve_matrix(
         int order, int num_control_points, int u_der, np.ndarray[double] u_vec, np.ndarray[double] knot_vector,
+        np.ndarray[int] u_i_starts,
         int num_points, 
         np.ndarray[double] data, np.ndarray[int] row_indices, np.ndarray[int] col_indices):
     get_basis_curve_matrix(
         order, num_control_points, u_der, &u_vec[0], &knot_vector[0],
+        &u_i_starts[0],
         num_points, &data[0], &row_indices[0], &col_indices[0],
     )

--- a/lsdo_genie/bsplines/cython/basis_matrix_surface.pxd
+++ b/lsdo_genie/bsplines/cython/basis_matrix_surface.pxd
@@ -7,6 +7,8 @@ from lsdo_genie.bsplines.cython.basis2 cimport get_basis2
 
 cdef get_basis_surface_matrix(
     int order_u, int num_control_points_u, int u_der, double* u_vec, double* knot_vector_u,
+    int* u_i_start, 
     int order_v, int num_control_points_v, int v_der, double* v_vec, double* knot_vector_v,
+    int* v_i_start, 
     int num_points, double* data, int* row_indices, int* col_indices,
 )

--- a/lsdo_genie/bsplines/cython/basis_matrix_surface.pyx
+++ b/lsdo_genie/bsplines/cython/basis_matrix_surface.pyx
@@ -4,12 +4,14 @@ from lsdo_genie.bsplines.cython.basis0 cimport get_basis0
 from lsdo_genie.bsplines.cython.basis1 cimport get_basis1
 from lsdo_genie.bsplines.cython.basis2 cimport get_basis2
 
-ctypedef int (*get_basis_func)(int order, int num_control_points, double u, double* knot_vector, double* basis)
+ctypedef int (*get_basis_func)(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis)
 
 
 cdef get_basis_surface_matrix(
     int order_u, int num_control_points_u, int u_der, double* u_vec, double* knot_vector_u,
+    int* u_i_starts,
     int order_v, int num_control_points_v, int v_der, double* v_vec, double* knot_vector_v,
+    int* v_i_starts,
     int num_points, double* data, int* row_indices, int* col_indices,
 ):
     cdef int i_pt, i_order_u, i_order_v, i_start_u, i_start_v, i_nz
@@ -38,8 +40,8 @@ cdef get_basis_surface_matrix(
 
     i_nz = 0
     for i_pt in range(num_points):
-        i_start_u = get_basis_u(order_u, num_control_points_u, u_vec[i_pt], knot_vector_u, basis_u)
-        i_start_v = get_basis_v(order_v, num_control_points_v, v_vec[i_pt], knot_vector_v, basis_v)
+        i_start_u = get_basis_u(order_u, num_control_points_u, u_vec[i_pt], u_i_starts[i_pt], knot_vector_u, basis_u)
+        i_start_v = get_basis_v(order_v, num_control_points_v, v_vec[i_pt], v_i_starts[i_pt], knot_vector_v, basis_v)
 
         for i_order_u in range(order_u):
             for i_order_v in range(order_v):

--- a/lsdo_genie/bsplines/cython/basis_matrix_surface_py.pyx
+++ b/lsdo_genie/bsplines/cython/basis_matrix_surface_py.pyx
@@ -6,11 +6,15 @@ from lsdo_genie.bsplines.cython.basis_matrix_surface cimport get_basis_surface_m
 
 def get_basis_surface_matrix(
         int order_u, int num_control_points_u, int u_der, np.ndarray[double] u_vec, np.ndarray[double] knot_vector_u,
+        np.ndarray[int] u_i_starts,
         int order_v, int num_control_points_v, int v_der, np.ndarray[double] v_vec, np.ndarray[double] knot_vector_v,
+        np.ndarray[int] v_i_starts,
         int num_points, 
         np.ndarray[double] data, np.ndarray[int] row_indices, np.ndarray[int] col_indices):
     get_basis_surface_matrix(
         order_u, num_control_points_u, u_der, &u_vec[0], &knot_vector_u[0],
+        &u_i_starts[0],
         order_v, num_control_points_v, v_der, &v_vec[0], &knot_vector_v[0],
+        &v_i_starts[0],
         num_points, &data[0], &row_indices[0], &col_indices[0],
     )

--- a/lsdo_genie/bsplines/cython/basis_matrix_volume.pxd
+++ b/lsdo_genie/bsplines/cython/basis_matrix_volume.pxd
@@ -7,7 +7,10 @@ from lsdo_genie.bsplines.cython.basis2 cimport get_basis2
 
 cdef get_basis_volume_matrix(
     int order_u, int num_control_points_u, int u_der, double* u_vec, double* knot_vector_u,
+    int* u_i_starts,
     int order_v, int num_control_points_v, int v_der, double* v_vec, double* knot_vector_v,
+    int* v_i_starts,
     int order_w, int num_control_points_w, int w_der, double* w_vec, double* knot_vector_w,
+    int* w_i_starts,
     int num_points, double* data, int* row_indices, int* col_indices,
 )

--- a/lsdo_genie/bsplines/cython/basis_matrix_volume.pyx
+++ b/lsdo_genie/bsplines/cython/basis_matrix_volume.pyx
@@ -4,13 +4,16 @@ from lsdo_genie.bsplines.cython.basis0 cimport get_basis0
 from lsdo_genie.bsplines.cython.basis1 cimport get_basis1
 from lsdo_genie.bsplines.cython.basis2 cimport get_basis2
 
-ctypedef int (*get_basis_func)(int order, int num_control_points, double u, double* knot_vector, double* basis)
+ctypedef int (*get_basis_func)(int order, int num_control_points, double u, int i_start, double* knot_vector, double* basis)
 
 
 cdef get_basis_volume_matrix(
     int order_u, int num_control_points_u, int u_der, double* u_vec, double* knot_vector_u,
+    int* u_i_starts,
     int order_v, int num_control_points_v, int v_der, double* v_vec, double* knot_vector_v,
+    int* v_i_starts,
     int order_w, int num_control_points_w, int w_der, double* w_vec, double* knot_vector_w,
+    int* w_i_starts,
     int num_points, double* data, int* row_indices, int* col_indices,
 ):
     cdef int i_pt, i_order_u, i_order_v, i_order_w, i_start_u, i_start_v, i_start_w, i_nz
@@ -44,9 +47,9 @@ cdef get_basis_volume_matrix(
 
     i_nz = 0
     for i_pt in range(num_points):
-        i_start_u = get_basis_u(order_u, num_control_points_u, u_vec[i_pt], knot_vector_u, basis_u)
-        i_start_v = get_basis_v(order_v, num_control_points_v, v_vec[i_pt], knot_vector_v, basis_v)
-        i_start_w = get_basis_w(order_w, num_control_points_w, w_vec[i_pt], knot_vector_w, basis_w)
+        i_start_u = get_basis_u(order_u, num_control_points_u, u_vec[i_pt], u_i_starts[i_pt],  knot_vector_u, basis_u)
+        i_start_v = get_basis_v(order_v, num_control_points_v, v_vec[i_pt], v_i_starts[i_pt],  knot_vector_v, basis_v)
+        i_start_w = get_basis_w(order_w, num_control_points_w, w_vec[i_pt], w_i_starts[i_pt], knot_vector_w, basis_w)
 
         for i_order_u in range(order_u):
             for i_order_v in range(order_v):

--- a/lsdo_genie/bsplines/cython/basis_matrix_volume_py.pyx
+++ b/lsdo_genie/bsplines/cython/basis_matrix_volume_py.pyx
@@ -6,14 +6,20 @@ from lsdo_genie.bsplines.cython.basis_matrix_volume cimport get_basis_volume_mat
 
 def get_basis_volume_matrix(
         int order_u, int num_control_points_u, int u_der, np.ndarray[double] u_vec, np.ndarray[double] knot_vector_u,
+        np.ndarray[int] u_i_starts,
         int order_v, int num_control_points_v, int v_der, np.ndarray[double] v_vec, np.ndarray[double] knot_vector_v,
+        np.ndarray[int] v_i_starts,
         int order_w, int num_control_points_w, int w_der, np.ndarray[double] w_vec, np.ndarray[double] knot_vector_w,
+        np.ndarray[int] w_i_starts,
         int num_points, 
         np.ndarray[double] data, np.ndarray[int] row_indices, np.ndarray[int] col_indices):
     get_basis_volume_matrix(
         order_u, num_control_points_u, u_der, &u_vec[0], &knot_vector_u[0],
+        &u_i_starts[0],
         order_v, num_control_points_v, v_der, &v_vec[0], &knot_vector_v[0],
+        &v_i_starts[0],
         order_w, num_control_points_w, w_der, &w_vec[0], &knot_vector_w[0],
+        &w_i_starts[0],
         num_points, &data[0], &row_indices[0], &col_indices[0],
     )
     

--- a/lsdo_genie/utils/data_visualizers.py
+++ b/lsdo_genie/utils/data_visualizers.py
@@ -34,8 +34,10 @@ def visualize_2Dptcloud(points:np.ndarray, normals:np.ndarray, show_normals:bool
             else: 
                 plt.arrow(x, y, nx*normal_length, ny*normal_length, color='b', head_width=.2)
     plt.title(title)
-    plt.legend()
+    plt.legend(loc='upper right')
     plt.axis('equal')
+    plt.xlabel("x")
+    plt.ylabel("y")
     sns.despine()
     plt.show()
 


### PR DESCRIPTION
## Summary
### Overview
USERS MUST NOW RECOMPILE THE CYTHON FILES TO WORK
B-Spline classes and cython files were updated to remove the binary search for the knot interval start. This improves the computation time to compute the Basis matrices.

### Context
This is an advantage we should have been taking advantage of before with the use of standard uniform knot vectors.

## Checklist
<!-- Make sure PR will have minimal conflicts -->
- [x] All existing tests have passed
- [x] No local merge conflicts
- [x] Code is commented
- [x] Added tests for new features (if needed)

### New Dependencies

USERS MUST NOW RECOMPILE THE CYTHON FILES TO WORK